### PR TITLE
Make env variables available in PHP - clearing environment in FPM workers

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -30,13 +30,6 @@ if [ ! -z "$OPENSHIFT_APP_DNS" ]; then
   fi
 fi
 
-if [ ! -z "$OPENSHIFT_SECRET_TOKEN" ]; then
-  export APP_KEY=${OPENSHIFT_SECRET_TOKEN:0:31}
-  if [ "$(type -t set_env_var)" == "function" ]; then
-    set_env_var 'APP_KEY' $APP_KEY $OPENSHIFT_HOMEDIR/.env/user_vars
-  fi
-fi
-
 if [ ! -z "$OPENSHIFT_POSTGRESQL_DB_HOST" ]; then
   export DB_CONNECTION="pgsql"
 fi
@@ -118,3 +111,10 @@ fi
 
 # .openshift/action_hooks/deploy
 ( cd $OPENSHIFT_REPO_DIR ; composer install --no-interaction --no-dev )
+
+if [ ! -z "$OPENSHIFT_SECRET_TOKEN" ]; then  
+  export APP_KEY="$(php $OPENSHIFT_REPO_DIR/artisan key:generate | grep -o '\[.*\]' | tr -d ‘[]’)";
+  if [ "$(type -t set_env_var)" == "function" ]; then
+    set_env_var 'APP_KEY' $APP_KEY $OPENSHIFT_HOMEDIR/.env/user_vars
+  fi
+fi

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -31,7 +31,7 @@ if [ ! -z "$OPENSHIFT_APP_DNS" ]; then
 fi
 
 if [ ! -z "$OPENSHIFT_SECRET_TOKEN" ]; then
-  export APP_KEY=${OPENSHIFT_SECRET_TOKEN:0:31}
+  export APP_KEY=${OPENSHIFT_SECRET_TOKEN:0:32}
   if [ "$(type -t set_env_var)" == "function" ]; then
     set_env_var 'APP_KEY' $APP_KEY $OPENSHIFT_HOMEDIR/.env/user_vars
   fi

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -115,3 +115,6 @@ ln -sf ${OPENSHIFT_LOG_DIR}   ${OPENSHIFT_DATA_DIR}storage/logs
 if [  -f ${OPENSHIFT_REPO_DIR}.openshift/.env ]; then
   cp -f ${OPENSHIFT_REPO_DIR}.openshift/.env ${OPENSHIFT_REPO_DIR}/.env
 fi
+
+# .openshift/action_hooks/deploy
+( cd $OPENSHIFT_REPO_DIR ; composer install --no-interaction --no-dev )

--- a/.openshift/action_hooks/pre_restart
+++ b/.openshift/action_hooks/pre_restart
@@ -40,7 +40,7 @@ if [ ! -z "$OPENSHIFT_APP_DNS" ]; then
 fi
 
 if [ ! -z "$OPENSHIFT_SECRET_TOKEN" ]; then
-  export APP_KEY=${OPENSHIFT_SECRET_TOKEN:0:31}
+  export APP_KEY=${OPENSHIFT_SECRET_TOKEN:0:32}
   if [ "$(type -t set_env_var)" == "function" ]; then
     set_env_var 'APP_KEY' $APP_KEY $OPENSHIFT_HOMEDIR/.env/user_vars
   fi

--- a/.openshift/action_hooks/pre_restart
+++ b/.openshift/action_hooks/pre_restart
@@ -39,13 +39,6 @@ if [ ! -z "$OPENSHIFT_APP_DNS" ]; then
   fi
 fi
 
-if [ ! -z "$OPENSHIFT_SECRET_TOKEN" ]; then
-  export APP_KEY=${OPENSHIFT_SECRET_TOKEN:0:32}
-  if [ "$(type -t set_env_var)" == "function" ]; then
-    set_env_var 'APP_KEY' $APP_KEY $OPENSHIFT_HOMEDIR/.env/user_vars
-  fi
-fi
-
 if [ ! -z "$OPENSHIFT_POSTGRESQL_DB_HOST" ]; then
   export DB_CONNECTION="pgsql"
 fi
@@ -75,5 +68,16 @@ else
   echo 1>&2
   if [ "$(type -t set_env_var)" == "function" ]; then
     set_env_var 'DB_CONNECTION' $DB_CONNECTION $OPENSHIFT_HOMEDIR/.env/user_vars
+  fi
+fi
+
+
+# .openshift/action_hooks/deploy
+( cd $OPENSHIFT_REPO_DIR ; composer install --no-interaction --no-dev )
+
+if [ ! -z "$OPENSHIFT_SECRET_TOKEN" ]; then  
+  export APP_KEY="$(php $OPENSHIFT_REPO_DIR/artisan key:generate | grep -o '\[.*\]' | tr -d ‘[]’)";
+  if [ "$(type -t set_env_var)" == "function" ]; then
+    set_env_var 'APP_KEY' $APP_KEY $OPENSHIFT_HOMEDIR/.env/user_vars
   fi
 fi

--- a/.openshift/fpm/php-fpm.conf.erb
+++ b/.openshift/fpm/php-fpm.conf.erb
@@ -487,7 +487,7 @@ pm.max_spare_servers = 3
 ; Setting to "no" will make all environment variables available to PHP code
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
-;clear_env = no
+clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit


### PR DESCRIPTION
This resolves an issue where the environment variables are not accessible in PHP as Nginx fpm is not releasing them. Therefore Laravel could not see them using getenv() function in either the $_ENV array or the $_SERVER arrays.
